### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/src/Identity.Server.MVC/package.json
+++ b/src/Identity.Server.MVC/package.json
@@ -14,6 +14,7 @@
     "tailwindcss": "^3.4.7"
   },
   "dependencies": {
-    "flowbite": "^2.5.2"
+    "flowbite": "^2.5.2",
+    "dompurify": "^3.2.3"
   }
 }

--- a/src/Identity.Server.MVC/wwwroot/js/signin-redirect.js
+++ b/src/Identity.Server.MVC/wwwroot/js/signin-redirect.js
@@ -1,1 +1,4 @@
-window.location.href = document.querySelector("meta[http-equiv=refresh]").getAttribute("data-url");
+const dirtyUrl = document.querySelector("meta[http-equiv=refresh]").getAttribute("data-url");
+const cleanUrl = DOMPurify.sanitize(dirtyUrl);
+window.location.href = cleanUrl;
+import DOMPurify from 'dompurify';


### PR DESCRIPTION
Potential fix for [https://github.com/LefterisRentas/IdentityServer/security/code-scanning/1](https://github.com/LefterisRentas/IdentityServer/security/code-scanning/1)

To fix the problem, we need to ensure that the URL extracted from the `data-url` attribute is properly sanitized before being used. One way to achieve this is by using a well-known library like DOMPurify to sanitize the URL. This will help prevent any malicious content from being executed.

1. Import the DOMPurify library.
2. Use DOMPurify to sanitize the URL extracted from the `data-url` attribute before assigning it to `window.location.href`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
