### PR TITLE
Potential fix for code scanning alert no. 9: User-controlled bypass of sensitive method

### DIFF
--- a/src/Identity.Server.MVC/Controllers/Account/AccountController.cs
+++ b/src/Identity.Server.MVC/Controllers/Account/AccountController.cs
@@ -93,7 +93,7 @@ public class AccountController : Controller
         var context = await _interaction.GetAuthorizationContextAsync(model.ReturnUrl);
 
         // the user clicked the "cancel" button
-        if (button != "login")
+        if (button == "cancel")
         {
             if (context == null) return Redirect("~/");
             // if the user cancels, send a result back into Identity.Server.MVC as if they 
@@ -110,7 +110,12 @@ public class AccountController : Controller
             }
 
             return Redirect(model.ReturnUrl ?? string.Empty);
-            // since we don't have a valid context, then we just go back to the home page
+        }
+        else if (button != "login")
+        {
+            // handle unexpected button values
+            _logger.LogWarning("Unexpected button value: {Button}", button);
+            return Redirect("~/");
         }
 
         if (ModelState.IsValid)


### PR DESCRIPTION
Potential fix for [https://github.com/LefterisRentas/IdentityServer/security/code-scanning/9](https://github.com/LefterisRentas/IdentityServer/security/code-scanning/9)

To fix the problem, we need to ensure that the decision to deny authorization is not based solely on the user-controlled `button` parameter. Instead, we should validate the `button` parameter and ensure it matches expected values before proceeding with sensitive actions. This can be achieved by explicitly checking for valid button values and handling unexpected values appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
