### PR TITLE
Potential fix for code scanning alert no. 8: Log entries created from user input

### DIFF
--- a/src/Identity.Server.MVC/Services/Mock/MockSmsService.cs
+++ b/src/Identity.Server.MVC/Services/Mock/MockSmsService.cs
@@ -15,7 +15,9 @@ public class MockSmsService : ISmsService
     
     public Task SendSmsAsync(string phoneNumber, string message)
     {
-        _logger.LogInformation($"Sending SMS to {phoneNumber} with message: {message}");
+        var sanitizedPhoneNumber = phoneNumber.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+        var sanitizedMessage = message.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+        _logger.LogInformation($"Sending SMS to {sanitizedPhoneNumber} with message: {sanitizedMessage}");
         return Task.CompletedTask;
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/LefterisRentas/IdentityServer/security/code-scanning/8](https://github.com/LefterisRentas/IdentityServer/security/code-scanning/8)

To fix the problem, we need to sanitize the user input before logging it. Specifically, we should remove any newline characters from the `phoneNumber` and `message` parameters to prevent log forging. This can be done using the `Replace` method to remove newline characters. Additionally, we should ensure that the user input is clearly marked in the log entries to avoid confusion.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
