### PR TITLE
Potential fix for code scanning alert no. 5: Cross-site scripting

### DIFF
--- a/src/Identity.Server.MVC/Controllers/Account/AccountController.cs
+++ b/src/Identity.Server.MVC/Controllers/Account/AccountController.cs
@@ -69,6 +69,8 @@ public class AccountController : Controller
     [Route("login")]
     public async Task<IActionResult> Login(string returnUrl)
     {
+        // Encode the returnUrl to prevent XSS
+        returnUrl = System.Net.WebUtility.HtmlEncode(returnUrl);
         // build a model so we know what to show on the login page
         var vm = await BuildLoginViewModelAsync(returnUrl);
 


### PR DESCRIPTION
Potential fix for [https://github.com/LefterisRentas/IdentityServer/security/code-scanning/5](https://github.com/LefterisRentas/IdentityServer/security/code-scanning/5)

To fix the cross-site scripting vulnerability, we need to sanitize the `returnUrl` parameter before it is used in the view. The best way to do this is to use the `System.Net.WebUtility.HtmlEncode` method to encode the `returnUrl` parameter. This will ensure that any potentially malicious scripts in the `returnUrl` are encoded and rendered harmless.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
