### PR TITLE
Potential fix for code scanning alert no. 6: Log entries created from user input

### DIFF
--- a/src/Identity.Server.MVC/Controllers/Consent/ConsentController.cs
+++ b/src/Identity.Server.MVC/Controllers/Consent/ConsentController.cs
@@ -169,7 +169,8 @@ public class ConsentController : Controller
         {
             return CreateConsentViewModel(model, returnUrl, request);
         }
-        _logger.LogError("No consent request matching request: {0}", returnUrl);
+        var sanitizedReturnUrl = returnUrl.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+        _logger.LogError("No consent request matching request: {0}", sanitizedReturnUrl);
 
         return null;
     }


### PR DESCRIPTION
Potential fix for [https://github.com/LefterisRentas/IdentityServer/security/code-scanning/6](https://github.com/LefterisRentas/IdentityServer/security/code-scanning/6)

To fix the problem, we need to sanitize the `returnUrl` before logging it. Since the log entries are plain text, we should remove any new line characters from the `returnUrl` to prevent log forging. This can be done using the `String.Replace` method to replace new line characters with an empty string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
