### PR TITLE
Potential fix for code scanning alert no. 7: Log entries created from user input

### DIFF
--- a/src/Identity.Server.MVC/Controllers/Account/TwoFactorController.cs
+++ b/src/Identity.Server.MVC/Controllers/Account/TwoFactorController.cs
@@ -105,7 +105,8 @@ public class TwoFactorController : Controller
         }
 
         var provider = user.TwoFactorProvider == TwoFactorProviders.Phone ? "Phone" : "Email";
-        _logger.LogInformation($"Provider: {provider}, Code: {model.Code}, User: {user.UserName}");
+        var sanitizedCode = model.Code.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+        _logger.LogInformation($"Provider: {provider}, Code: {sanitizedCode}, User: {user.UserName}");
 
         // Verify the code
         var result = await _signInManager.TwoFactorSignInAsync(provider, model.Code, model.RememberMe, model.RememberBrowser);


### PR DESCRIPTION
Potential fix for [https://github.com/LefterisRentas/IdentityServer/security/code-scanning/7](https://github.com/LefterisRentas/IdentityServer/security/code-scanning/7)

To fix the problem, we need to sanitize the user input before logging it. Specifically, we should remove any newline characters from `model.Code` to prevent log forging. This can be done using the `Replace` method to ensure that the user input does not contain any newline characters.

We will modify the log entry on line 108 to sanitize `model.Code` before logging it. This involves replacing newline characters with an empty string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
