### PR TITLE
Potential fix for code scanning alert no. 5: Cross-site scripting

### DIFF
--- a/src/Identity.Server.MVC/Controllers/Account/AccountController.cs
+++ b/src/Identity.Server.MVC/Controllers/Account/AccountController.cs
@@ -362,7 +362,7 @@ public class AccountController : Controller
         {
             AllowRememberLogin = AccountOptions.AllowRememberLogin,
             EnableLocalLogin = allowLocal && AccountOptions.AllowLocalLogin,
-            ReturnUrl = returnUrl,
+            ReturnUrl = System.Net.WebUtility.HtmlEncode(returnUrl),
             Username = context?.LoginHint ?? string.Empty,
             ExternalProviders = providers.ToArray()
         };

--- a/src/Identity.Server.MVC/Views/Account/Login.cshtml
+++ b/src/Identity.Server.MVC/Views/Account/Login.cshtml
@@ -78,7 +78,7 @@
                                asp-controller="External"
                                asp-action="Challenge"
                                asp-route-scheme="@provider.AuthenticationScheme"
-                               asp-route-returnUrl="@Model.ReturnUrl">
+                               asp-route-returnUrl="@Html.Raw(Model.ReturnUrl)">
                                 <i class="@iconClass mr-2"></i> @provider.DisplayName
                             </a>
                         </li>


### PR DESCRIPTION
Potential fix for [https://github.com/LefterisRentas/IdentityServer/security/code-scanning/5](https://github.com/LefterisRentas/IdentityServer/security/code-scanning/5)

To fix the cross-site scripting vulnerability, we need to ensure that the `ReturnUrl` is properly encoded before being rendered in the HTML. The best way to do this is to use the `System.Net.WebUtility.HtmlEncode` method to encode the `ReturnUrl` before it is used in the view.

1. In the `AccountController`, encode the `ReturnUrl` before passing it to the view model.
2. Ensure that the encoded `ReturnUrl` is used in the Razor view.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
