### PR TITLE
Potential fix for code scanning alert no. 3: URL redirection from remote source

### DIFF
--- a/src/Identity.Server.MVC/Controllers/Account/AccountController.cs
+++ b/src/Identity.Server.MVC/Controllers/Account/AccountController.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+using System;
+using System.Web;
 
 
 using System;
@@ -24,6 +26,15 @@ using Microsoft.Extensions.Logging;
 
 namespace Identity.Server.MVC.Controllers.Account;
 
+public bool IsValidReturnUrl(string returnUrl)
+{
+    var url = new Uri(returnUrl, UriKind.RelativeOrAbsolute);
+    if (!url.IsAbsoluteUri)
+    {
+        return true;
+    }
+    return url.Host == "example.org"; // Replace with your known good host
+}
 [Route("account")]
 [SecurityHeaders]
 [AllowAnonymous]
@@ -111,7 +122,12 @@ public class AccountController : Controller
                 return this.LoadingPage("Redirect", model.ReturnUrl ?? string.Empty);
             }
 
-            return Redirect(model.ReturnUrl ?? string.Empty);
+            var returnUrl = model.ReturnUrl ?? string.Empty;
+            if (IsValidReturnUrl(returnUrl))
+            {
+                return Redirect(returnUrl);
+            }
+            return Redirect("~/");
             // since we don't have a valid context, then we just go back to the home page
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/LefterisRentas/IdentityServer/security/code-scanning/3](https://github.com/LefterisRentas/IdentityServer/security/code-scanning/3)

To fix the problem, we need to validate the `ReturnUrl` before using it in a redirect. We can maintain a list of authorized redirects or ensure that the URL is either relative or on a known good host. This will prevent attackers from redirecting users to malicious sites.

The best way to fix the problem without changing existing functionality is to add a validation step for the `ReturnUrl`. We will check if the URL is either relative or belongs to a known good host before performing the redirect.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
